### PR TITLE
added standalone multisort implementation to file_browser example

### DIFF
--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -184,20 +184,6 @@
             };
         }
 
-        function styleColumnSortArrows(sort, ths) {
-            const sort_obj = Object.fromEntries(sort);
-            for (const th of ths) {
-                let col = th.firstElementChild.textContent;
-                if (!col) {
-                    col = "path";
-                    th.firstElementChild.textContent = col;
-                }
-
-                const sort_dir = sort_obj[col];
-                th.className = sort_dir ? `rt-sort-${sort_dir}` : "";
-            }
-        }
-
         function updateSort(sort, column_name, multi) {
             const current_idx = sort.findIndex((x) => x[0] === column_name);
             if (current_idx > -1) {
@@ -222,7 +208,23 @@
             return sort;
         }
 
-        function sortFileSystemContentsList(contents_list, sort, ths, column_name, multi) {
+        function _flattenContents(contents, sorter, contents_list) {
+            if (!contents) {
+                // bail
+                return contents_list;
+            }
+
+            for (const subcontents of sorter ? contents.contents?.sort(sorter) : contents.contents) {
+                contents_list.push(subcontents);
+                if (subcontents.is_open) {
+                    _flattenContents(subcontents, sorter, contents_list);
+                }
+            }
+
+            return contents_list;
+        }
+
+        function getSortedContents(root, sort, expand, column_name, multi) {
             // update sort orders, if requested
             if (column_name) {
                 sort = updateSort(sort, column_name, multi);
@@ -231,27 +233,27 @@
                 sort = sort.length > 0 ? sort : [["path", "asc"]];
             }
 
-            // sort the data
-            contents_list.sort(contentsSorterClosure(sort));
+            const sorter = contentsSorterClosure(sort);
 
-            // style column header sort icons
-            styleColumnSortArrows(sort, ths);
-
-            return sort;
+            // get contents, then sort/flatten and return them
+            const contents = window.getFileSystemContents(root, expand);
+            return [_flattenContents(contents, sorter, []), sort];
         }
 
-        window.sortFileSystemContentsList = sortFileSystemContentsList;
+        window.getSortedContents = getSortedContents;
     </script>
 
     <script>
         const COLUMN_HEADERS = ["modified", "kind", "writable"];
         const DATE_FORMATTER = new Intl.DateTimeFormat("en-us");
-        let SORT;
+        let ROOT = [];
         const TABLE = document.getElementsByTagName("regular-table")[0];
         const TEMPLATE = document.createElement("template");
-        const VIEW_STATE = window.getFileSystemContents([], true).contents;
 
-        // Splice out the contents of the collapsed node and any expanded subnodes
+        // set initial sort while also creating the root contents
+        let [VIEW_STATE, SORT] = window.getSortedContents(ROOT, [["path", "asc"]], true);
+
+        // splice out the contents of the collapsed node and any expanded subnodes
         async function collapse(rix) {
             VIEW_STATE[rix].is_open = false;
             const contents = window.getFileSystemContents(VIEW_STATE[rix].path);
@@ -266,8 +268,9 @@
 
         async function expand(rix) {
             VIEW_STATE[rix].is_open = true;
-            const contents = window.getFileSystemContents(VIEW_STATE[rix].path, true);
-            VIEW_STATE.splice(rix + 1, 0, ...contents.contents);
+
+            const [contents_list] = window.getSortedContents(VIEW_STATE[rix].path, SORT, true);
+            VIEW_STATE.splice(rix + 1, 0, ...contents_list);
         }
 
         function tree_header_levels(path, is_open, is_leaf) {
@@ -311,6 +314,14 @@
         }
 
         function file_browser_style() {
+            // style the column header sort carets
+            const sort_obj = Object.fromEntries(SORT);
+            for (const th of TABLE.get_ths()) {
+                const sort_dir = sort_obj[th.firstElementChild.textContent || "path"];
+                th.className = sort_dir ? `rt-sort-${sort_dir}` : "";
+            }
+
+            // style the browser's filetype icons
             const trs = TABLE.querySelectorAll("tr");
             for (const tr of trs) {
                 const {children} = tr;
@@ -333,7 +344,7 @@
                 const column_name = metadata.column_name || "path";
                 const multi = event.shiftKey;
 
-                SORT = window.sortFileSystemContentsList(VIEW_STATE, [...SORT], TABLE.get_ths(), column_name, multi);
+                [VIEW_STATE, SORT] = window.getSortedContents(ROOT, SORT, false, column_name, multi);
                 TABLE.draw({invalid_viewport: true});
             }
         }
@@ -354,10 +365,6 @@
             TABLE.addClickListener(file_browser_on_sort_click);
             TABLE.addClickListener(file_browser_on_tree_click);
             TABLE.addStyleListener(file_browser_style);
-            await TABLE.draw();
-
-            // do initial sort
-            SORT = window.sortFileSystemContentsList(VIEW_STATE, [["path", "asc"]], TABLE.get_ths());
             await TABLE.draw();
         });
     </script>

--- a/examples/file_browser.html
+++ b/examples/file_browser.html
@@ -22,7 +22,17 @@
     <link rel='stylesheet' href="../dist/css/material.css">
 
     <style>
-        .rt-browser-icon:before {
+        :root {
+            --rt-dir-icon: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTAgNEg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMThjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY4YzAtMS4xLS45LTItMi0yaC04bC0yLTJ6Ii8+PC9zdmc+");
+            --rt-text-icon: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTUgMTVIM3YyaDEydi0yem0wLThIM3YyaDEyVjd6TTMgMTNoMTh2LTJIM3Yyem0wIDhoMTh2LTJIM3Yyek0zIDN2MmgxOFYzSDN6Ii8+PC9zdmc+");
+
+            --rt-caret-left: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij48cGF0aCBkPSJNMTAuOCAxMi44TDcuMSA5bDMuOC0zLjh2Ny42aC0uMXoiIGZpbGw9IiM2MTYxNjEiIHNoYXBlLXJlbmRlcmluZz0iZ2VvbWV0cmljUHJlY2lzaW9uIi8+PC9zdmc+");
+            --rt-caret-up: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij48cGF0aCBkPSJNNS4yIDEwLjVMOSA2LjhsMy44IDMuOEg1LjJ6IiBmaWxsPSIjNjE2MTYxIiBzaGFwZS1yZW5kZXJpbmc9Imdlb21ldHJpY1ByZWNpc2lvbiIvPjwvc3ZnPg==");
+            --rt-caret-right: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij48cGF0aCBkPSJNNy4yIDUuMkwxMC45IDlsLTMuOCAzLjhWNS4yaC4xeiIgZmlsbD0iIzYxNjE2MSIgc2hhcGUtcmVuZGVyaW5nPSJnZW9tZXRyaWNQcmVjaXNpb24iLz48L3N2Zz4=");
+            --rt-caret-down: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDE4IDE4Ij48cGF0aCBkPSJNNS4yIDcuNUw5IDExLjJsMy44LTMuOEg1LjJ6IiBmaWxsPSIjNjE2MTYxIiBzaGFwZS1yZW5kZXJpbmc9Imdlb21ldHJpY1ByZWNpc2lvbiIvPjwvc3ZnPg==");
+        }
+
+        .rt-browser-filetype-icon:before {
             content: "";
             float: left;
             margin-right: 5px;
@@ -32,11 +42,28 @@
         }
 
         .rt-browser-dir-icon:before {
-            background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTAgNEg0Yy0xLjEgMC0xLjk5LjktMS45OSAyTDIgMThjMCAxLjEuOSAyIDIgMmgxNmMxLjEgMCAyLS45IDItMlY4YzAtMS4xLS45LTItMi0yaC04bC0yLTJ6Ii8+PC9zdmc+");
+            background-image: var(--rt-dir-icon);
         }
 
         .rt-browser-text-icon:before {
-            background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBjbGFzcz0ianAtaWNvbjMganAtaWNvbi1zZWxlY3RhYmxlIiBmaWxsPSIjNjE2MTYxIiBkPSJNMTUgMTVIM3YyaDEydi0yem0wLThIM3YyaDEyVjd6TTMgMTNoMTh2LTJIM3Yyem0wIDhoMTh2LTJIM3Yyek0zIDN2MmgxOFYzSDN6Ii8+PC9zdmc+");
+            background-image: var(--rt-text-icon);
+        }
+
+        thead th span:first-child {
+            background-position: right;
+            background-repeat: no-repeat;
+            background-size: 16px;
+            min-width: 16px;
+            min-height: 16px;
+            padding-right: 16px;
+        }
+
+        thead th.rt-sort-asc span:first-child {
+            background-image: var(--rt-caret-up);
+        }
+
+        thead th.rt-sort-desc span:first-child {
+            background-image: var(--rt-caret-down);
         }
 
         table {
@@ -86,17 +113,20 @@
 
         function getFileSystemContents(path, expand) {
             // infinite recursive mock contents
+            const key = path.join("");
+
             let contents;
-            if (CONTENTS_CACHE.has(path)) {
-                contents = CONTENTS_CACHE.get(path);
+            if (CONTENTS_CACHE.has(key)) {
+                contents = CONTENTS_CACHE.get(key);
             } else {
                 contents = {
                     path,
+                    is_open: false,
                     modified: new Date(12 * 60 * 60 * 1000),
                     kind: "dir",
                     writable: false,
                 };
-                CONTENTS_CACHE.set(path, contents);
+                CONTENTS_CACHE.set(key, contents);
             }
 
             if (!expand || "contents" in contents) {
@@ -112,7 +142,7 @@
                     writable: false,
                 };
 
-                CONTENTS_CACHE.set(subcontents.path, subcontents);
+                CONTENTS_CACHE.set(subcontents.path.join(""), subcontents);
                 contents.contents.push(subcontents);
             }
 
@@ -123,13 +153,103 @@
     </script>
 
     <script>
-        const COLUMN_HEADERS = ["modified", "kind", "writable"];
+        const SORT_DIRS = ["asc", "desc", null];
 
+        function contentsSorterClosure(sort) {
+            // map sort direction string onto sort direction sign
+            const signs = sort.map(([col, dir]) => [col, dir.startsWith("desc") ? -1 : 1]);
+
+            return function contentsSorter(lrow, rrow) {
+                for (const [col, sign] of signs) {
+                    let cmp;
+                    let lval = lrow[col];
+                    let rval = rrow[col];
+
+                    if (Array.isArray(lval)) {
+                        lval = lval[lval.length - 1];
+                        rval = rval[rval.length - 1];
+                    }
+
+                    if (typeof lval === "string") {
+                        cmp = lval.localeCompare(rval);
+                    } else {
+                        cmp = lval - rval;
+                    }
+
+                    if (cmp) {
+                        return sign * cmp;
+                    }
+                }
+                return 0;
+            };
+        }
+
+        function styleColumnSortArrows(sort, ths) {
+            const sort_obj = Object.fromEntries(sort);
+            for (const th of ths) {
+                let col = th.firstElementChild.textContent;
+                if (!col) {
+                    col = "path";
+                    th.firstElementChild.textContent = col;
+                }
+
+                const sort_dir = sort_obj[col];
+                th.className = sort_dir ? `rt-sort-${sort_dir}` : "";
+            }
+        }
+
+        function updateSort(sort, column_name, multi) {
+            const current_idx = sort.findIndex((x) => x[0] === column_name);
+            if (current_idx > -1) {
+                const old_dir = sort[current_idx][1];
+                const sort_dir = SORT_DIRS[(SORT_DIRS.indexOf(old_dir) + 1) % SORT_DIRS.length];
+                if (sort_dir) {
+                    // update the sort_dir
+                    sort[current_idx] = [column_name, sort_dir];
+                } else {
+                    // remove this column from the sort
+                    sort.splice(current_idx, 1);
+                }
+            } else {
+                const new_sort = [column_name, SORT_DIRS[0]];
+                if (multi) {
+                    sort.push(new_sort);
+                } else {
+                    sort = [new_sort];
+                }
+            }
+
+            return sort;
+        }
+
+        function sortFileSystemContentsList(contents_list, sort, ths, column_name, multi) {
+            // update sort orders, if requested
+            if (column_name) {
+                sort = updateSort(sort, column_name, multi);
+
+                // if sort is empty, use a default sort
+                sort = sort.length > 0 ? sort : [["path", "asc"]];
+            }
+
+            // sort the data
+            contents_list.sort(contentsSorterClosure(sort));
+
+            // style column header sort icons
+            styleColumnSortArrows(sort, ths);
+
+            return sort;
+        }
+
+        window.sortFileSystemContentsList = sortFileSystemContentsList;
+    </script>
+
+    <script>
+        const COLUMN_HEADERS = ["modified", "kind", "writable"];
         const DATE_FORMATTER = new Intl.DateTimeFormat("en-us");
+        let SORT;
+        const TABLE = document.getElementsByTagName("regular-table")[0];
         const TEMPLATE = document.createElement("template");
         const VIEW_STATE = window.getFileSystemContents([], true).contents;
-
-        const TABLE = document.getElementsByTagName("regular-table")[0];
 
         // Splice out the contents of the collapsed node and any expanded subnodes
         async function collapse(rix) {
@@ -198,19 +318,28 @@
                 for (let i = 1; i < children.length; i++) {
                     const text = children[i].textContent;
                     if (text === "dir") {
-                        row_name_node.classList.add("rt-browser-icon", "rt-browser-dir-icon");
+                        row_name_node.classList.add("rt-browser-filetype-icon", "rt-browser-dir-icon");
                         break;
                     } else if (text === "text") {
-                        row_name_node.classList.add("rt-browser-icon", "rt-browser-text-icon");
+                        row_name_node.classList.add("rt-browser-filetype-icon", "rt-browser-text-icon");
                         break;
                     }
                 }
             }
         }
 
-        function file_browser_on_click(event) {
+        function file_browser_on_sort_click(event, tx_element, metadata) {
+            if (metadata?.is_column_header) {
+                const column_name = metadata.column_name || "path";
+                const multi = event.shiftKey;
+
+                SORT = window.sortFileSystemContentsList(VIEW_STATE, [...SORT], TABLE.get_ths(), column_name, multi);
+                TABLE.draw({invalid_viewport: true});
+            }
+        }
+
+        function file_browser_on_tree_click(event, tx_element, metadata) {
             if (event.target.tagName === "SPAN" && event.target.className === "pd-row-header-icon") {
-                const metadata = TABLE.getMeta(event.target.parentElement.parentElement);
                 if (VIEW_STATE[metadata.y].is_open) {
                     collapse(metadata.y);
                 } else {
@@ -222,8 +351,13 @@
 
         window.addEventListener("DOMContentLoaded", async function () {
             TABLE.setDataListener(file_browser_model);
+            TABLE.addClickListener(file_browser_on_sort_click);
+            TABLE.addClickListener(file_browser_on_tree_click);
             TABLE.addStyleListener(file_browser_style);
-            TABLE.addEventListener("click", file_browser_on_click);
+            await TABLE.draw();
+
+            // do initial sort
+            SORT = window.sortFileSystemContentsList(VIEW_STATE, [["path", "asc"]], TABLE.get_ths());
             await TABLE.draw();
         });
     </script>

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -121,6 +121,11 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
         const metadata = METADATA_MAP.get(element);
         if (is_resize) {
             this._on_resize_column(event, element, metadata);
+        } else {
+            // skip callbacks if this is a resize event
+            for (const callback of this._click_callbacks.values()) {
+                await callback(event, element, metadata);
+            }
         }
     }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -33,6 +33,7 @@ class RegularTableElement extends RegularViewEventModel {
         this.register_listeners();
         this.setAttribute("tabindex", "0");
         this._column_sizes = {auto: {}, override: {}, indices: []};
+        this._click_callbacks = new Map();
         this._style_callbacks = new Map();
         this.table_model = new RegularTableViewModel(this._table_clip, this._column_sizes, this._sticky_container);
         if (!this.table_model) return;
@@ -65,6 +66,12 @@ class RegularTableElement extends RegularViewEventModel {
         this.scrollTop = 0;
         this.scrollLeft = 0;
         this.reset_viewport();
+    }
+
+    addClickListener(clickListener) {
+        const key = this._click_callbacks.size;
+        this._click_callbacks.set(key, clickListener);
+        return key;
     }
 
     addStyleListener(styleListener) {

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -23,7 +23,6 @@ export class RegularHeaderViewModel extends ViewModel {
     _draw_group_th(offset_cache, d, column, sort_dir) {
         const th = this._get_cell("TH", d, offset_cache[d]);
         offset_cache[d] += 1;
-        th.className = "";
         th.removeAttribute("colspan");
         th.style.minWidth = "0";
         if (sort_dir?.length === 0) {
@@ -63,7 +62,6 @@ export class RegularHeaderViewModel extends ViewModel {
         metadata.column_path = column;
         metadata.column_name = column_name;
         metadata.is_column_header = false;
-        th.className = "";
         return metadata;
     }
 

--- a/test/file_browser.test.js
+++ b/test/file_browser.test.js
@@ -143,9 +143,9 @@ describe("file_browser.html", () => {
                 const first_tr = await page.$(first_tr_selector);
                 const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
                 expect(cell_values).toEqual([
-                    "file_89.txt",
-                    "4/9/1972",
-                    "text",
+                    "add jig/",
+                    "1/10/1972",
+                    "dir",
                     "false"
                 ]);
             });

--- a/test/file_browser.test.js
+++ b/test/file_browser.test.js
@@ -9,14 +9,75 @@
  */
 
 describe("file_browser.html", () => {
+    const first_tr_selector = "regular-table tbody tr:first-child";
+    const first_row_header_icon_selector = `${first_tr_selector} .pd-row-header-icon`;
+    const header_th_selector = "regular-table thead th"
+
+    let table;
+
+    async function cell_values_at(cix, rix, ncol, nrow) {
+        await page.evaluate(async (table, cix, rix, ncol, nrow) => {
+            table.scrollTo(cix, rix, ncol, nrow);
+            await table.draw();
+        }, table, cix, rix, ncol, nrow);
+
+        return await first_cell_values();
+    }
+
+    async function click_col_header(cix, reps, shift) {
+        const ths = await page.$$(header_th_selector);
+
+        for (let i = 0; i < reps; i++) {
+            if (shift) {
+                // shift click the column header
+                await page.keyboard.down('Shift');
+                await ths[cix].click();
+                await page.keyboard.up('Shift');
+            } else {
+                await ths[cix].click();
+            }
+        }
+    }
+
+    async function first_cell_values() {
+        const tr = await page.$(first_tr_selector);
+        return await page.evaluate((tr) => Array.from(tr.children).map((x) => x.textContent.trim()), tr);
+    }
+
+    async function refresh_page() {
+        await page.goto("http://localhost:8081/examples/file_browser.html");
+        await page.waitFor("regular-table table tbody tr td");
+
+        table = await page.$("regular-table");
+    }
+
+    async function reset_scroll() {
+        await page.evaluate(async (table) => {
+            await table.draw({reset_scroll_position: true});
+        }, table);
+    }
+
+    async function toggle_first_row() {
+        let first_row_header_icon = await page.$(first_row_header_icon_selector);
+        await first_row_header_icon.click();
+    }
+
+    async function toggle_row_at(rix, ncol, nrow) {
+        await page.evaluate(async (table, rix, ncol, nrow) => {
+            table.scrollTo(0, rix, ncol, nrow);
+            await table.draw();
+        }, table, rix, ncol, nrow);
+
+        await toggle_first_row();
+    }
+
     beforeAll(async () => {
         await page.setViewport({width: 400, height: 100});
     });
 
     describe("creates a `<table>` body when attached to `document`", () => {
         beforeAll(async () => {
-            await page.goto("http://localhost:8081/examples/file_browser.html");
-            await page.waitFor("regular-table table tbody tr td");
+            await refresh_page();
         });
 
         test("with the correct # of rows", async () => {
@@ -26,14 +87,13 @@ describe("file_browser.html", () => {
         });
 
         test("with the correct # of columns", async () => {
-            const first_tr = await page.$("regular-table tbody tr:first-child");
+            const first_tr = await page.$(first_tr_selector);
             const num_cells_rendered = await page.evaluate((first_tr) => first_tr.children.length, first_tr);
             expect(num_cells_rendered).toEqual(4);
         });
 
         test("with the first row's cell test correct", async () => {
-            const first_tr = await page.$("regular-table tbody tr:first-child");
-            const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+            const cell_values = await first_cell_values();
             expect(cell_values).toEqual([
                 "add able/",
                 "1/1/1971",
@@ -45,18 +105,11 @@ describe("file_browser.html", () => {
 
     describe("scrolls via scrollTo() method", () => {
         beforeAll(async () => {
-            await page.goto("http://localhost:8081/examples/file_browser.html");
-            await page.waitFor("regular-table table tbody tr td");
+            await refresh_page();
         });
 
         test("to (0, 1)", async () => {
-            const table = await page.$("regular-table");
-            await page.evaluate(async (table) => {
-                table.scrollTo(0, 1, 4, 100);
-                await table.draw();
-            }, table);
-            const first_tr = await page.$("regular-table tbody tr:first-child");
-            const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+            const cell_values = await cell_values_at(0, 1, 4, 100);
             expect(cell_values).toEqual([
                 "add baker/",
                 "1/2/1971",
@@ -66,13 +119,7 @@ describe("file_browser.html", () => {
         });
 
         test("to (0, 79)", async () => {
-            const table = await page.$("regular-table");
-            await page.evaluate(async (table) => {
-                table.scrollTo(0, 79, 4, 100);
-                await table.draw();
-            }, table);
-            const first_tr = await page.$("regular-table tbody tr:first-child");
-            const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+            const cell_values = await cell_values_at(0, 79, 4, 100);
             expect(cell_values).toEqual([
                 "file_76.txt",
                 "3/28/1971",
@@ -83,28 +130,18 @@ describe("file_browser.html", () => {
     });
 
     describe("expands and collapses tree rows", () => {
-        const first_tr_selector = "regular-table tbody tr:first-child";
-        const first_row_header_icon_selector = `${first_tr_selector} .pd-row-header-icon`;
-
         beforeAll(async () => {
-            // refresh page
-            await page.goto("http://localhost:8081/examples/file_browser.html");
-            await page.waitFor("regular-table table tbody tr td");
+            await refresh_page();
         });
 
         describe("expands", () => {
             beforeAll(async () => {
                 // expand first directory row
-                let first_row_header_icon = await page.$(first_row_header_icon_selector);
-                await first_row_header_icon.click();
+                await toggle_first_row();
             });
 
             afterAll(async () => {
-                // reset scroll position
-                const table = await page.$("regular-table");
-                await page.evaluate(async (table) => {
-                    await table.draw({reset_scroll_position: true});
-                }, table);
+                await reset_scroll();
             });
 
             test("expand the first tree row", async () => {
@@ -116,14 +153,7 @@ describe("file_browser.html", () => {
 
             test("first row added by expand is correct", async () => {
                 // scroll to and test first row added by expand
-                const table = await page.$("regular-table");
-                await page.evaluate(async (table) => {
-                    table.scrollTo(0, 1, 4, 200);
-                    await table.draw();
-                }, table);
-
-                const first_tr = await page.$(first_tr_selector);
-                const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+                const cell_values = await cell_values_at(0, 1, 4, 200);
                 expect(cell_values).toEqual([
                     "add able/",
                     "1/1/1972",
@@ -134,14 +164,7 @@ describe("file_browser.html", () => {
 
             test("last row added by expand is correct", async () => {
                 // scroll to and test first row added by expand
-                const table = await page.$("regular-table");
-                await page.evaluate(async (table) => {
-                    table.scrollTo(0, 100, 4, 200);
-                    await table.draw();
-                }, table);
-
-                const first_tr = await page.$(first_tr_selector);
-                const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+                const cell_values = await cell_values_at(0, 100, 4, 200);
                 expect(cell_values).toEqual([
                     "add jig/",
                     "1/10/1972",
@@ -154,16 +177,11 @@ describe("file_browser.html", () => {
         describe("collapses", () => {
             beforeAll(async () => {
                 // collapse first directory row
-                let first_row_header_icon = await page.$(first_row_header_icon_selector);
-                await first_row_header_icon.click();
+                await toggle_first_row();
             });
 
             afterAll(async () => {
-                // reset scroll position
-                const table = await page.$("regular-table");
-                await page.evaluate(async (table) => {
-                    await table.draw({reset_scroll_position: true});
-                }, table);
+                await reset_scroll();
             });
 
             test("collapse the first tree row", async () => {
@@ -175,14 +193,7 @@ describe("file_browser.html", () => {
 
             test("collapse restores previous rows", async () => {
                 // scroll to and test the next row after the collapsed row
-                const table = await page.$("regular-table");
-                await page.evaluate(async (table) => {
-                    table.scrollTo(0, 1, 4, 100);
-                    await table.draw();
-                }, table);
-
-                const first_tr = await page.$(first_tr_selector);
-                const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
+                const cell_values = await cell_values_at(0, 1, 4, 100);
                 expect(cell_values).toEqual([
                     "add baker/",
                     "1/2/1971",
@@ -190,6 +201,150 @@ describe("file_browser.html", () => {
                     "false"
                 ]);
             });
+        });
+    });
+
+    describe("sorts flat filebrowser by one or more columns", () => {
+        beforeAll(async () => {
+            await refresh_page();
+        });
+
+        test("by default, sorts by path, ascending", async () => {
+            const vals = [];
+            for (let i = 0; i < 10; i++) {
+                const cell_values = await cell_values_at(0, i, 4, 100);
+                vals.push(cell_values[0]);
+            }
+            expect(vals).toEqual([
+                "add able/",
+                "add baker/",
+                "add charlie/",
+                "add dog/",
+                "add easy/",
+                "file_0.txt",
+                "file_1.txt",
+                "file_10.txt",
+                "file_11.txt",
+                "file_12.txt",
+            ]);
+        });
+
+        test("sort by a single column correctly, descending", async () => {
+            // click twice on the "modified" column
+            await click_col_header(1, 2);
+
+            const vals = [];
+            for (let i = 0; i < 10; i++) {
+                const cell_values = await cell_values_at(0, i, 4, 100);
+                vals.push(cell_values[1]);
+            }
+            expect(vals).toEqual([
+                "4/10/1971",
+                "4/9/1971",
+                "4/8/1971",
+                "4/7/1971",
+                "4/6/1971",
+                "4/5/1971",
+                "4/4/1971",
+                "4/3/1971",
+                "4/2/1971",
+                "4/1/1971",
+            ]);
+        });
+
+        test("sort by two columns correctly, [ascending, descending]", async () => {
+            // click one on the "kind" column
+            await click_col_header(2, 1);
+            // shift-click twice on the "modified" column
+            await click_col_header(1, 2, true);
+
+            const vals = [];
+            for (let i = 5; i < 15; i++) {
+                const cell_values = await cell_values_at(0, i, 4, 100);
+                vals.push(cell_values[1]);
+            }
+            expect(vals).toEqual([
+                "1/5/1971",
+                "1/4/1971",
+                "1/3/1971",
+                "1/2/1971",
+                "1/1/1971",
+                "4/10/1971",
+                "4/9/1971",
+                "4/8/1971",
+                "4/7/1971",
+                "4/6/1971",
+            ]);
+        });
+    });
+
+    describe("sorts tree filebrowser", () => {
+        beforeEach(async () => {
+            await refresh_page();
+        });
+
+        test("uses same sort at all levels, sort then expand tree", async () => {
+            // click one on the "kind" column
+            await click_col_header(2, 1);
+            // shift-click twice on the "modified" column
+            await click_col_header(1, 2, true);
+
+            // expand the "easy/" dir, then the "easy/easy" dir
+            await toggle_row_at(5, 4, 100);
+            await toggle_row_at(11, 4, 200);
+
+            const offsets = [200, 106, 12];
+            for (const offset of offsets) {
+                const vals = [];
+                for (let i = 6 + offset; i < 16 + offset; i++) {
+                    const cell_values = await cell_values_at(0, i, 4, 300);
+                    vals.push(cell_values[0]);
+                }
+                expect(vals).toEqual([
+                    "add dog/",
+                    "add charlie/",
+                    "add baker/",
+                    "add able/",
+                    "file_89.txt",
+                    "file_88.txt",
+                    "file_87.txt",
+                    "file_86.txt",
+                    "file_85.txt",
+                    "file_84.txt",
+                ]);
+            }
+        });
+
+        test("uses same sort at all levels, expand tree then sort", async () => {
+            // expand the "easy/" dir, then the "easy/easy" dir
+            await toggle_row_at(4, 4, 100);
+            await toggle_row_at(9, 4, 200);
+
+            // click one on the "kind" column
+            await click_col_header(2, 1);
+            // shift-click twice on the "modified" column
+            await click_col_header(1, 2, true);
+
+            const offsets = [200, 106, 12];
+            for (const offset of offsets) {
+                const vals = [];
+                for (let i = 6 + offset; i < 16 + offset; i++) {
+                    const cell_values = await cell_values_at(0, i, 4, 300);
+                    vals.push(cell_values[0]);
+                }
+                expect(vals).toEqual([
+                    "add dog/",
+                    "add charlie/",
+                    "add baker/",
+                    "add able/",
+                    "file_89.txt",
+                    "file_88.txt",
+                    "file_87.txt",
+                    "file_86.txt",
+                    "file_85.txt",
+                    "file_84.txt",
+                ]);
+            }
         });
     });
 });

--- a/test/file_browser.test.js
+++ b/test/file_browser.test.js
@@ -74,8 +74,8 @@ describe("file_browser.html", () => {
             const first_tr = await page.$("regular-table tbody tr:first-child");
             const cell_values = await page.evaluate((first_tr) => Array.from(first_tr.children).map((x) => x.textContent.trim()), first_tr);
             expect(cell_values).toEqual([
-                "file_69.txt",
-                "3/21/1971",
+                "file_76.txt",
+                "3/28/1971",
                 "text",
                 "false",
             ]);


### PR DESCRIPTION
Adds a standalone implementation of multisort to the `file_browser.html` example. Slightly simplified, but mostly equivalent to the one recently removed from `events.js`:

![image](https://user-images.githubusercontent.com/2263641/83535807-6bf33b00-a4c0-11ea-9238-580b7fc1efce.png)