### PR TITLE
FIx column resize & row height viewport bugs

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -279,7 +279,7 @@ export class RegularViewEventModel extends RegularVirtualTableViewModel {
         // If the column is smaller, new columns may need to be fetched, so
         // redraw, else just update the DOM widths as if redrawn.
         if (diff < 0) {
-            await this.draw({ preserve_width: true });
+            await this.draw({ preserve_width: true, throttle: false });
         } else {
             th.style.minWidth = override_width + "px";
             th.style.maxWidth = override_width + "px";

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -358,9 +358,14 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      * @param {DrawOptions} [options]
      * @param {boolean} [options.invalid_viewport=true]
      * @param {boolean} [options.preserve_width=false]
+     * @param {boolean} [options.throttle=true]
      */
     async draw(options = {}) {
-        return await throttle_tag(this, () => internal_draw.call(this, [options]));
+        if (typeof options.throttle !== "undefined" && !options.throttle) {
+            return await internal_draw.call(this, [options]);
+        } else {
+            return await throttle_tag(this, () => internal_draw.call(this, [options]));
+        }
     }
 
     async _draw_flush() {
@@ -393,7 +398,6 @@ async function internal_draw(options) {
     if (!preserve_width) {
         this._update_virtual_panel_width(invalid_viewport, num_columns);
     }
-
     const viewport = this._calculate_viewport(num_rows, num_columns);
     const { invalid_row, invalid_column } = this._validate_viewport(viewport);
     if (this._invalid_schema || invalid_row || invalid_column || invalid_viewport) {

--- a/src/js/table.js
+++ b/src/js/table.js
@@ -57,7 +57,7 @@ export class RegularTableViewModel {
         while (last_cells.length > 0) {
             const [cell, metadata] = last_cells.pop();
             const box = cell.getBoundingClientRect();
-            this._column_sizes.row_height = this._column_sizes.row_height || box.height;
+            this._column_sizes.row_height = box.height;
             this._column_sizes.indices[metadata.size_key] = box.width;
             const is_override = this._column_sizes.override[metadata.size_key] !== undefined;
             if (box.width && !is_override) {


### PR DESCRIPTION
* Fixes a bug which causes the viewport to be calculated as too small (due to memoizing a bad row height).
* Fixes a bug which causes a deadlock (unresponsive grid) when shrinking a column below its autosize minimum.