### PR TITLE
Add `column_header_merge_depth` and `row_height` page options

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,16 @@ field will accompany the metadata records returned by `regular-table`'s
 }
 ```
 
+### Rendering Options
+
+There are some additional values which can be configured for specialty use:
+
+* `column_header_merge_depth: number` configures the number of rows to include
+  from `colspan` merging. This defaults to `header_length - 1`.
+* `row_height: number` configures the pixel height of a row for
+  virtual scrolling calculation. This is typically auto-detected from the DOM,
+  but can be overridden if needed.
+
 ### `async` Data Models
 
 With an `async` data model, it's easy to serve `getDataSlice()` remotely from

--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -388,7 +388,7 @@ export class RegularVirtualTableViewModel extends HTMLElement {
 async function internal_draw(options) {
     const __debug_start_time__ = DEBUG && performance.now();
     const { invalid_viewport = true, preserve_width = false } = options;
-    const { num_columns, num_rows } = await this._view_cache.view(0, 0, 0, 0);
+    const { num_columns, num_rows, row_height } = await this._view_cache.view(0, 0, 0, 0);
     this._container_size = {
         width: this._virtual_mode === "none" || this._virtual_mode === "vertical" ? Infinity : this._table_clip.clientWidth,
         height: this._virtual_mode === "none" || this._virtual_mode === "horizontal" ? Infinity : this._table_clip.clientHeight,
@@ -430,7 +430,7 @@ async function internal_draw(options) {
             this._invalidated = false;
         }
 
-        this.table_model.autosize_cells(autosize_cells);
+        this.table_model.autosize_cells(autosize_cells, row_height);
         this.table_model.header.reset_header_cache();
         if (!preserve_width) {
             this._update_virtual_panel_width(this._invalid_schema || invalid_column, num_columns);

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -84,14 +84,16 @@ export class RegularHeaderViewModel extends ViewModel {
         return this._get_cell("TH", this.num_rows() - 1, cidx);
     }
 
-    draw(alias, parts, colspan, x, size_key, x0, _virtual_x) {
+    draw(alias, parts, colspan, x, size_key, x0, _virtual_x, column_header_merge_depth) {
         const header_levels = parts?.length; //config.column_pivots.length + 1;
         if (header_levels === 0) return;
         let th, metadata, column_name;
+        column_header_merge_depth = typeof column_header_merge_depth === "undefined" ? header_levels - 1 : column_header_merge_depth;
         for (let d = 0; d < header_levels; d++) {
             column_name = parts[d] ? parts[d] : "";
             this._offset_cache[d] = this._offset_cache[d] || 0;
-            if (d < header_levels - 1) {
+
+            if (d < column_header_merge_depth) {
                 if (this._group_header_cache?.[d]?.[0]?.value === column_name) {
                     th = this._group_header_cache[d][1];
                     this._group_header_cache[d][2] += 1;


### PR DESCRIPTION
Adds two new non-data-specific configuration options to the schema of the `dataListener` return object:

* `column_header_merge_depth: number` configures the number of rows to include
  from `colspan` merging. This defaults to `header_length - 1`.
* `row_height: number` configures the pixel height of a row for
  virtual scrolling calculation. This is typically auto-detected from the DOM,
  but can be overridden if needed.