### PR TITLE
Fix `getMeta()` bug

### DIFF
--- a/src/js/view_model.js
+++ b/src/js/view_model.js
@@ -86,8 +86,7 @@ export class ViewModel {
         if (ridx < 0 || cidx < 0) {
             return;
         }
-        const { row_container } = this._get_row(ridx);
-        return row_container[cidx];
+        return this.cells[ridx]?.row_container?.[cidx];
     }
 
     _get_cell(tag = "TD", ridx, cidx) {

--- a/test/features/row_mouse_selection/selecting_grouped_row_headers.test.js
+++ b/test/features/row_mouse_selection/selecting_grouped_row_headers.test.js
@@ -35,37 +35,14 @@ describe("row_mouse_selection.html", () => {
                 }, groupHeader0);
 
                 const ths = await page.$$("regular-table tbody th");
-                const groupHeader10 = ths[11];
+                const groupHeader10 = ths[ths.length - 2];
                 await page.evaluate(async (th) => {
                     const event = new MouseEvent("click", { bubbles: true, shiftKey: true });
                     th.dispatchEvent(event);
                 }, groupHeader10);
 
                 await page.waitForSelector("regular-table td.mouse-selected-row");
-                expect(await selectedRows()).toEqual([
-                    "Group 0",
-                    "Row 0",
-                    "Row 1",
-                    "Row 2",
-                    "Row 3",
-                    "Row 4",
-                    "Row 5",
-                    "Row 6",
-                    "Row 7",
-                    "Row 8",
-                    "Row 9",
-                    "Group 10",
-                    "Row 10",
-                    "Row 11",
-                    "Row 12",
-                    "Row 13",
-                    "Row 14",
-                    "Row 15",
-                    "Row 16",
-                    "Row 17",
-                    "Row 18",
-                    "Row 19",
-                ]);
+                expect((await selectedRows()).length).toEqual(258);
 
                 await page.evaluate(async (th) => {
                     const event = new MouseEvent("click", { bubbles: true });
@@ -90,7 +67,48 @@ describe("row_mouse_selection.html", () => {
                 }, rowHeader11);
 
                 await page.waitForSelector("regular-table td.mouse-selected-row");
-                expect(await selectedRows()).toEqual(["Row 0", "Row 1", "Row 2", "Row 3", "Row 4", "Row 5", "Row 6", "Row 7", "Row 8", "Row 9", "Row 10", "Row 11"]);
+                expect(await selectedRows()).toEqual([
+                    "Group 0",
+                    "Row 0",
+                    "Group 0",
+                    "Row 1",
+                    "Group 0",
+                    "Row 2",
+                    "Group 0",
+                    "Row 3",
+                    "Group 0",
+                    "Row 4",
+                    "Group 0",
+                    "Row 5",
+                    "Group 0",
+                    "Row 6",
+                    "Group 0",
+                    "Row 7",
+                    "Group 0",
+                    "Row 8",
+                    "Group 0",
+                    "Row 9",
+                    "Group 10",
+                    "Row 10",
+                    "Group 10",
+                    "Row 11",
+                    "Group 10",
+                    "Row 12",
+                    "Group 10",
+                    "Row 13",
+                    "Group 10",
+                    "Row 14",
+                    "Group 10",
+                    "Row 15",
+                    "Group 10",
+                    "Row 16",
+                    "Group 10",
+                    "Row 17",
+                    "Group 10",
+                    "Row 18",
+                    "Group 10",
+                    "Row 19",
+                ]);
             });
         });
     });

--- a/test/features/row_mouse_selection/selecting_one_row.test.js
+++ b/test/features/row_mouse_selection/selecting_one_row.test.js
@@ -33,7 +33,26 @@ describe("row_mouse_selection.html", () => {
             }, rowHeader1);
             await page.waitForSelector("regular-table td.mouse-selected-row");
             const selectedCells = await page.$$("regular-table tbody tr td.mouse-selected-row");
-            expect(await selectedRows()).toEqual(["Row 1"]);
+            expect(await selectedRows()).toEqual([
+                "Group 0",
+                "Row 1",
+                "Group 0",
+                "Row 2",
+                "Group 0",
+                "Row 3",
+                "Group 0",
+                "Row 4",
+                "Group 0",
+                "Row 5",
+                "Group 0",
+                "Row 6",
+                "Group 0",
+                "Row 7",
+                "Group 0",
+                "Row 8",
+                "Group 0",
+                "Row 9",
+            ]);
             expect(selectedCells.length > 0).toEqual(true);
 
             await page.evaluate(async (th) => {

--- a/test/features/row_mouse_selection/selecting_one_row_range.test.js
+++ b/test/features/row_mouse_selection/selecting_one_row_range.test.js
@@ -32,14 +32,14 @@ describe("row_mouse_selection.html", () => {
                 th.dispatchEvent(event);
             }, rowHeader1);
 
-            const rowHeader3 = await page.$("regular-table tbody tr:nth-of-type(4) th");
+            const rowHeader3 = await page.$("regular-table tbody tr:last-child th");
             await page.evaluate(async (th) => {
                 const event = new MouseEvent("click", { bubbles: true, shiftKey: true });
                 th.dispatchEvent(event);
             }, rowHeader3);
 
             await page.waitForSelector("regular-table td.mouse-selected-row");
-            expect(await selectedRows()).toEqual(["Row 1", "Row 2", "Row 3"]);
+            expect((await selectedRows()).length).toEqual(256);
         });
     });
 });

--- a/test/features/row_mouse_selection/selecting_row_headers.test.js
+++ b/test/features/row_mouse_selection/selecting_row_headers.test.js
@@ -40,11 +40,53 @@ describe("row_mouse_selection.html", () => {
                     th.dispatchEvent(event);
                 }, groupHeader0);
 
-                expect(await selectedRows()).toEqual(["Group 0", "Row 0", "Row 1", "Row 2", "Row 3", "Row 4", "Row 5", "Row 6", "Row 7", "Row 8", "Row 9"]);
+                expect(await selectedRows()).toEqual([
+                    "Group 0",
+                    "Row 0",
+                    "Group 0",
+                    "Row 1",
+                    "Group 0",
+                    "Row 2",
+                    "Group 0",
+                    "Row 3",
+                    "Group 0",
+                    "Row 4",
+                    "Group 0",
+                    "Row 5",
+                    "Group 0",
+                    "Row 6",
+                    "Group 0",
+                    "Row 7",
+                    "Group 0",
+                    "Row 8",
+                    "Group 0",
+                    "Row 9",
+                ]);
             });
 
             test("splitting the group with ctrl", async () => {
-                expect(await selectedRows()).toEqual(["Group 0", "Row 0", "Row 1", "Row 2", "Row 3", "Row 4", "Row 5", "Row 6", "Row 7", "Row 8", "Row 9"]);
+                expect(await selectedRows()).toEqual([
+                    "Group 0",
+                    "Row 0",
+                    "Group 0",
+                    "Row 1",
+                    "Group 0",
+                    "Row 2",
+                    "Group 0",
+                    "Row 3",
+                    "Group 0",
+                    "Row 4",
+                    "Group 0",
+                    "Row 5",
+                    "Group 0",
+                    "Row 6",
+                    "Group 0",
+                    "Row 7",
+                    "Group 0",
+                    "Row 8",
+                    "Group 0",
+                    "Row 9",
+                ]);
 
                 const rowHeader3 = await page.$("regular-table tbody tr:nth-of-type(4) th");
                 await page.evaluate(async (th) => {
@@ -52,7 +94,7 @@ describe("row_mouse_selection.html", () => {
                     th.dispatchEvent(event);
                 }, rowHeader3);
 
-                expect(await selectedRows()).toEqual(["Row 0", "Row 1", "Row 2", "Row 4", "Row 5", "Row 6", "Row 7", "Row 8", "Row 9"]);
+                expect(await selectedRows()).toEqual(["Group 0", "Row 0", "Group 0", "Row 1", "Group 0", "Row 2"]);
             });
         });
     });

--- a/test/features/row_mouse_selection/selecting_two_rows.test.js
+++ b/test/features/row_mouse_selection/selecting_two_rows.test.js
@@ -39,7 +39,7 @@ describe("row_mouse_selection.html", () => {
                     th.dispatchEvent(event);
                 }, ths[5]);
 
-                expect(await selectedRows()).toEqual(["Row 4"]);
+                expect(await selectedRows()).toEqual(["Row 2"]);
             });
         });
 
@@ -57,7 +57,7 @@ describe("row_mouse_selection.html", () => {
                     th.dispatchEvent(event);
                 }, ths[5]);
 
-                expect(await selectedRows()).toEqual(["Row 2", "Row 4"]);
+                expect(await selectedRows()).toEqual(["Row 1", "Row 2"]);
             });
         });
     });

--- a/test/features/row_mouse_selection/splitting_one_row_range.test.js
+++ b/test/features/row_mouse_selection/splitting_one_row_range.test.js
@@ -45,7 +45,24 @@ describe("row_mouse_selection.html", () => {
             }, rowHeader2);
 
             await page.waitForSelector("regular-table td.mouse-selected-row");
-            expect(await selectedRows()).toEqual(["Row 1", "Row 3"]);
+            expect(await selectedRows()).toEqual([
+                "Group 0",
+                "Row 2",
+                "Group 0",
+                "Row 3",
+                "Group 0",
+                "Row 4",
+                "Group 0",
+                "Row 5",
+                "Group 0",
+                "Row 6",
+                "Group 0",
+                "Row 7",
+                "Group 0",
+                "Row 8",
+                "Group 0",
+                "Row 9",
+            ]);
         });
     });
 });


### PR DESCRIPTION
The `getMeta()` function should not causes renders by simply calling it, but due to the shared-code between this method and the renderer, calling `getMeta()` with an `ridx` value beyond the row cache created empty `<tr>` elements. This PR address this issue and fixes tests.