### PR TITLE
Add `merge_headers` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,8 @@ elements in a sequence will be automatically merged via `rowspan` and `colspan`
 attributes. In this example, e.g. `"Rowgroup 1"` will only output to one `<th>`
 node in the resulting `<table>`.
 
+Header merging can be disabled with the `merge_headers` option.
+
 ### `metadata` Data-Aware Styling
 
 A `dataListener` may also optionally provide a `metadata` field in its response,
@@ -378,13 +380,17 @@ field will accompany the metadata records returned by `regular-table`'s
 
 ### Rendering Options
 
-There are some additional values which can be configured for specialty use:
+Additional rendering options which can be set on the object returned by a
+`setDataListener` callback include:
 
 * `column_header_merge_depth: number` configures the number of rows to include
   from `colspan` merging. This defaults to `header_length - 1`.
 * `row_height: number` configures the pixel height of a row for
   virtual scrolling calculation. This is typically auto-detected from the DOM,
   but can be overridden if needed.
+* `merge_headers: "column" | "row" | "both" | "none"` configures whether 
+  equivalent, contiguous `<th>` elements are merged via `rowspan` or `colspan`
+  for `"row"` and `"column"` respectively (defaults to `"both"`).
 
 ### `async` Data Models
 

--- a/src/js/tbody.js
+++ b/src/js/tbody.js
@@ -49,7 +49,7 @@ export class RegularBodyViewModel extends ViewModel {
         return { td, metadata };
     }
 
-    draw(container_height, column_state, view_state, th = false, x, x0, size_key) {
+    draw(container_height, column_state, view_state, th = false, x, x0, size_key, merge_headers) {
         const { cidx, column_data, row_headers, column_data_listener_metadata } = column_state;
         let { row_height } = view_state;
         let metadata;
@@ -71,11 +71,11 @@ export class RegularBodyViewModel extends ViewModel {
                     const prev_col = this._fetch_cell(ridx, cidx + i - (cidx_offset[ridx] || 1));
                     const prev_col_metadata = this._get_or_create_metadata(prev_col);
 
-                    if (prev_col && (prev_col_metadata.value === row_header || row_header === undefined) && !prev_col.hasAttribute("rowspan")) {
+                    if (merge_headers && prev_col && (prev_col_metadata.value === row_header || row_header === undefined) && !prev_col.hasAttribute("rowspan")) {
                         cidx_offset[ridx] = cidx_offset[ridx] ? cidx_offset[ridx] + 1 : 2;
                         prev_col.setAttribute("colspan", cidx_offset[ridx]);
                         this._replace_cell(ridx, cidx + i);
-                    } else if (prev_row && prev_row_metadata.value === row_header && !prev_row.hasAttribute("colspan")) {
+                    } else if (merge_headers && prev_row && prev_row_metadata.value === row_header && !prev_row.hasAttribute("colspan")) {
                         ridx_offset[i] = ridx_offset[i] ? ridx_offset[i] + 1 : 2;
                         prev_row.setAttribute("rowspan", ridx_offset[i]);
                         this._replace_cell(ridx, cidx + i);

--- a/src/js/thead.js
+++ b/src/js/thead.js
@@ -84,7 +84,7 @@ export class RegularHeaderViewModel extends ViewModel {
         return this._get_cell("TH", this.num_rows() - 1, cidx);
     }
 
-    draw(alias, parts, colspan, x, size_key, x0, _virtual_x, column_header_merge_depth) {
+    draw(alias, parts, colspan, x, size_key, x0, _virtual_x, column_header_merge_depth, merge_headers) {
         const header_levels = parts?.length; //config.column_pivots.length + 1;
         if (header_levels === 0) return;
         let th, metadata, column_name;
@@ -95,7 +95,7 @@ export class RegularHeaderViewModel extends ViewModel {
             this._offset_cache[d] = this._offset_cache[d] || 0;
 
             if (d < column_header_merge_depth) {
-                if (this._group_header_cache?.[d]?.[0]?.value === column_name) {
+                if (merge_headers && this._group_header_cache?.[d]?.[0]?.value === column_name) {
                     th = this._group_header_cache[d][1];
                     this._group_header_cache[d][2] += 1;
                     if (colspan === 1) {

--- a/src/js/view_model.js
+++ b/src/js/view_model.js
@@ -86,7 +86,23 @@ export class ViewModel {
         if (ridx < 0 || cidx < 0) {
             return;
         }
-        return this.cells[ridx]?.row_container?.[cidx];
+
+        return this.cells[ridx]?.[cidx];
+    }
+
+    _get_row(ridx) {
+        let tr = this.rows[ridx];
+        if (!tr) {
+            tr = this.rows[ridx] = document.createElement("tr");
+            this.table.appendChild(tr);
+        }
+
+        let row_container = this.cells[ridx];
+        if (!row_container) {
+            row_container = this.cells[ridx] = [];
+        }
+
+        return { tr, row_container };
     }
 
     _get_cell(tag = "TD", ridx, cidx) {
@@ -111,21 +127,6 @@ export class ViewModel {
             td = new_td;
         }
         return td;
-    }
-
-    _get_row(ridx) {
-        let tr = this.rows[ridx];
-        if (!tr) {
-            tr = this.rows[ridx] = document.createElement("tr");
-            this.table.appendChild(tr);
-        }
-
-        let row_container = this.cells[ridx];
-        if (!row_container) {
-            row_container = this.cells[ridx] = [];
-        }
-
-        return { tr, row_container };
     }
 
     _clean_columns(cidx) {

--- a/test/features/row_mouse_selection/selecting_grouped_row_headers.test.js
+++ b/test/features/row_mouse_selection/selecting_grouped_row_headers.test.js
@@ -35,14 +35,37 @@ describe("row_mouse_selection.html", () => {
                 }, groupHeader0);
 
                 const ths = await page.$$("regular-table tbody th");
-                const groupHeader10 = ths[ths.length - 2];
+                const groupHeader10 = ths[11];
                 await page.evaluate(async (th) => {
                     const event = new MouseEvent("click", { bubbles: true, shiftKey: true });
                     th.dispatchEvent(event);
                 }, groupHeader10);
 
                 await page.waitForSelector("regular-table td.mouse-selected-row");
-                expect((await selectedRows()).length).toEqual(258);
+                expect(await selectedRows()).toEqual([
+                    "Group 0",
+                    "Row 0",
+                    "Row 1",
+                    "Row 2",
+                    "Row 3",
+                    "Row 4",
+                    "Row 5",
+                    "Row 6",
+                    "Row 7",
+                    "Row 8",
+                    "Row 9",
+                    "Group 10",
+                    "Row 10",
+                    "Row 11",
+                    "Row 12",
+                    "Row 13",
+                    "Row 14",
+                    "Row 15",
+                    "Row 16",
+                    "Row 17",
+                    "Row 18",
+                    "Row 19",
+                ]);
 
                 await page.evaluate(async (th) => {
                     const event = new MouseEvent("click", { bubbles: true });
@@ -67,48 +90,7 @@ describe("row_mouse_selection.html", () => {
                 }, rowHeader11);
 
                 await page.waitForSelector("regular-table td.mouse-selected-row");
-                expect(await selectedRows()).toEqual([
-                    "Group 0",
-                    "Row 0",
-                    "Group 0",
-                    "Row 1",
-                    "Group 0",
-                    "Row 2",
-                    "Group 0",
-                    "Row 3",
-                    "Group 0",
-                    "Row 4",
-                    "Group 0",
-                    "Row 5",
-                    "Group 0",
-                    "Row 6",
-                    "Group 0",
-                    "Row 7",
-                    "Group 0",
-                    "Row 8",
-                    "Group 0",
-                    "Row 9",
-                    "Group 10",
-                    "Row 10",
-                    "Group 10",
-                    "Row 11",
-                    "Group 10",
-                    "Row 12",
-                    "Group 10",
-                    "Row 13",
-                    "Group 10",
-                    "Row 14",
-                    "Group 10",
-                    "Row 15",
-                    "Group 10",
-                    "Row 16",
-                    "Group 10",
-                    "Row 17",
-                    "Group 10",
-                    "Row 18",
-                    "Group 10",
-                    "Row 19",
-                ]);
+                expect(await selectedRows()).toEqual(["Row 0", "Row 1", "Row 2", "Row 3", "Row 4", "Row 5", "Row 6", "Row 7", "Row 8", "Row 9", "Row 10", "Row 11"]);
             });
         });
     });

--- a/test/features/row_mouse_selection/selecting_one_row.test.js
+++ b/test/features/row_mouse_selection/selecting_one_row.test.js
@@ -33,26 +33,7 @@ describe("row_mouse_selection.html", () => {
             }, rowHeader1);
             await page.waitForSelector("regular-table td.mouse-selected-row");
             const selectedCells = await page.$$("regular-table tbody tr td.mouse-selected-row");
-            expect(await selectedRows()).toEqual([
-                "Group 0",
-                "Row 1",
-                "Group 0",
-                "Row 2",
-                "Group 0",
-                "Row 3",
-                "Group 0",
-                "Row 4",
-                "Group 0",
-                "Row 5",
-                "Group 0",
-                "Row 6",
-                "Group 0",
-                "Row 7",
-                "Group 0",
-                "Row 8",
-                "Group 0",
-                "Row 9",
-            ]);
+            expect(await selectedRows()).toEqual(["Row 1"]);
             expect(selectedCells.length > 0).toEqual(true);
 
             await page.evaluate(async (th) => {

--- a/test/features/row_mouse_selection/selecting_one_row_range.test.js
+++ b/test/features/row_mouse_selection/selecting_one_row_range.test.js
@@ -32,14 +32,14 @@ describe("row_mouse_selection.html", () => {
                 th.dispatchEvent(event);
             }, rowHeader1);
 
-            const rowHeader3 = await page.$("regular-table tbody tr:last-child th");
+            const rowHeader3 = await page.$("regular-table tbody tr:nth-of-type(4) th");
             await page.evaluate(async (th) => {
                 const event = new MouseEvent("click", { bubbles: true, shiftKey: true });
                 th.dispatchEvent(event);
             }, rowHeader3);
 
             await page.waitForSelector("regular-table td.mouse-selected-row");
-            expect((await selectedRows()).length).toEqual(256);
+            expect(await selectedRows()).toEqual(["Row 1", "Row 2", "Row 3"]);
         });
     });
 });

--- a/test/features/row_mouse_selection/selecting_row_headers.test.js
+++ b/test/features/row_mouse_selection/selecting_row_headers.test.js
@@ -40,53 +40,11 @@ describe("row_mouse_selection.html", () => {
                     th.dispatchEvent(event);
                 }, groupHeader0);
 
-                expect(await selectedRows()).toEqual([
-                    "Group 0",
-                    "Row 0",
-                    "Group 0",
-                    "Row 1",
-                    "Group 0",
-                    "Row 2",
-                    "Group 0",
-                    "Row 3",
-                    "Group 0",
-                    "Row 4",
-                    "Group 0",
-                    "Row 5",
-                    "Group 0",
-                    "Row 6",
-                    "Group 0",
-                    "Row 7",
-                    "Group 0",
-                    "Row 8",
-                    "Group 0",
-                    "Row 9",
-                ]);
+                expect(await selectedRows()).toEqual(["Group 0", "Row 0", "Row 1", "Row 2", "Row 3", "Row 4", "Row 5", "Row 6", "Row 7", "Row 8", "Row 9"]);
             });
 
             test("splitting the group with ctrl", async () => {
-                expect(await selectedRows()).toEqual([
-                    "Group 0",
-                    "Row 0",
-                    "Group 0",
-                    "Row 1",
-                    "Group 0",
-                    "Row 2",
-                    "Group 0",
-                    "Row 3",
-                    "Group 0",
-                    "Row 4",
-                    "Group 0",
-                    "Row 5",
-                    "Group 0",
-                    "Row 6",
-                    "Group 0",
-                    "Row 7",
-                    "Group 0",
-                    "Row 8",
-                    "Group 0",
-                    "Row 9",
-                ]);
+                expect(await selectedRows()).toEqual(["Group 0", "Row 0", "Row 1", "Row 2", "Row 3", "Row 4", "Row 5", "Row 6", "Row 7", "Row 8", "Row 9"]);
 
                 const rowHeader3 = await page.$("regular-table tbody tr:nth-of-type(4) th");
                 await page.evaluate(async (th) => {
@@ -94,7 +52,7 @@ describe("row_mouse_selection.html", () => {
                     th.dispatchEvent(event);
                 }, rowHeader3);
 
-                expect(await selectedRows()).toEqual(["Group 0", "Row 0", "Group 0", "Row 1", "Group 0", "Row 2"]);
+                expect(await selectedRows()).toEqual(["Row 0", "Row 1", "Row 2", "Row 4", "Row 5", "Row 6", "Row 7", "Row 8", "Row 9"]);
             });
         });
     });

--- a/test/features/row_mouse_selection/selecting_two_rows.test.js
+++ b/test/features/row_mouse_selection/selecting_two_rows.test.js
@@ -39,7 +39,7 @@ describe("row_mouse_selection.html", () => {
                     th.dispatchEvent(event);
                 }, ths[5]);
 
-                expect(await selectedRows()).toEqual(["Row 2"]);
+                expect(await selectedRows()).toEqual(["Row 4"]);
             });
         });
 
@@ -57,7 +57,7 @@ describe("row_mouse_selection.html", () => {
                     th.dispatchEvent(event);
                 }, ths[5]);
 
-                expect(await selectedRows()).toEqual(["Row 1", "Row 2"]);
+                expect(await selectedRows()).toEqual(["Row 2", "Row 4"]);
             });
         });
     });

--- a/test/features/row_mouse_selection/splitting_one_row_range.test.js
+++ b/test/features/row_mouse_selection/splitting_one_row_range.test.js
@@ -45,24 +45,7 @@ describe("row_mouse_selection.html", () => {
             }, rowHeader2);
 
             await page.waitForSelector("regular-table td.mouse-selected-row");
-            expect(await selectedRows()).toEqual([
-                "Group 0",
-                "Row 2",
-                "Group 0",
-                "Row 3",
-                "Group 0",
-                "Row 4",
-                "Group 0",
-                "Row 5",
-                "Group 0",
-                "Row 6",
-                "Group 0",
-                "Row 7",
-                "Group 0",
-                "Row 8",
-                "Group 0",
-                "Row 9",
-            ]);
+            expect(await selectedRows()).toEqual(["Row 1", "Row 3"]);
         });
     });
 });


### PR DESCRIPTION
Adds `merge_headers` option, which can be `"both"` (default), `"row"`, `"horizontal"`, or `"none"`, similar to `virtual_mode` (but defined on the return object of a `setDataListener` callback, instead of as an optional argument). These new non-default modes disable merge behavior as described in "Column and row groups" in the documentation.

Fixes #193 