### PR TITLE
Fix viewport staleness check

### DIFF
--- a/src/js/scroll_panel.js
+++ b/src/js/scroll_panel.js
@@ -362,9 +362,9 @@ export class RegularVirtualTableViewModel extends HTMLElement {
      */
     async draw(options = {}) {
         if (typeof options.throttle !== "undefined" && !options.throttle) {
-            return await internal_draw.call(this, [options]);
+            return await internal_draw.call(this, options);
         } else {
-            return await throttle_tag(this, () => internal_draw.call(this, [options]));
+            return await throttle_tag(this, () => internal_draw.call(this, options));
         }
     }
 


### PR DESCRIPTION
Fixes a regression introduced in #184 which caused viewport to _always_ be considered stale, resulting in extraneous calls to the data listener which impacts scroll performance.